### PR TITLE
build: Update github-script to v7

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ jobs:
   pr-bot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;


### PR DESCRIPTION
Update `github-script` to v7. This removes a workflow warning.